### PR TITLE
Support for languages & filtering queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+install:
+  - pip install flake8==3.0.4
+script:
+  - flake8
+

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,4 @@
+v0.1.0, 2017-01-26 -- Initial release
+v0.1.1, 2017-01-26 -- Support filtering by domain in GSAClient
+v1.0.0, 2017-01-27 -- Support filtering by language; restructure data objects
+

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 ubuntudesign.gsa: Python GSA client
 ===================================
 
+.. image:: https://travis-ci.org/ubuntudesign/ubuntudesign.gsa.svg?branch=master
+   :alt: build status
+   :target: https://travis-ci.org/ubuntudesign/ubuntudesign.gsa
+
 A client library for the `Google Search Appliance <https://enterprise.google.com/search/products/gsa.html>`_, to make retrieving search results in Python easier.
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -1,26 +1,26 @@
-Python GSA
-==========
+ubuntudesign.gsa: Python GSA client
+===================================
 
-A client library for the [Google Search Appliance](https://enterprise.google.com/search/products/gsa.html), to make retrieving search results in Python easier.
+A client library for the `Google Search Appliance <https://enterprise.google.com/search/products/gsa.html>`_, to make retrieving search results in Python easier.
 
 Installation
-----
+------------
 
-This module is in PyPi as `ubuntudesign.gsa`. You should be able to install it simply with:
+This module is in PyPi as :code:`ubuntudesign.gsa`. You should be able to install it simply with:
 
 .. code:: bash
 
     pip install ubuntudesign.gsa
 
 GSAClient
-----
+---------
 
 This is a basic client for querying a Google Search Appliance.
 
 Making queries
-~~~
+~~~~~~~~~~~~~~
 
-You can query the GSA using the `search` method.
+You can query the GSA using the :code:`search` method.
 
 .. code:: python
 
@@ -34,16 +34,15 @@ You can query the GSA using the `search` method.
       "hello world", start=20, num=20
     )
 
-This will set the [`q`](https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1089652),
-[`start`](https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1076971) (default: 0) and
-[`num`](https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1076882) (default: 10) and
-[`lr`](https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1076879) (default: '') parameters.
-
-No other [search parameters](https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1086546),
+This will set the `q <https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1089652>`_,
+`start <https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1076971>`_ (default: 0) and
+`num <https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1076882>`_ (default: 10) and
+`lr <https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1076879>`_ (default: '') parameters.
+No other `search parameters <https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1086546>`_,
 will be provided, so they will all fall back to their defaults.
 
 The returned results object will attempt to map each of the GSA's
-[standard result XML tags](https://www.google.com/support/enterprise/static/gsa/docs/admin/70/gsa_doc_set/xml_reference/results_format.html#1078461)
+`standard result XML tags <https://www.google.com/support/enterprise/static/gsa/docs/admin/70/gsa_doc_set/xml_reference/results_format.html#1078461>`_
 into a more readable format:
 
 .. code:: python
@@ -55,20 +54,20 @@ into a more readable format:
         'previous_url': str,             # "PU": Ditto for previous set of results
         'items': [
             {
-                'index': int,         # "R[N]": The number of this result in the index of all results
-                'url': str,           # "U": The URL of the resulting page
-                'encoded_url': str,   # "UE": The above URL, encoded
-                'title': str,         # "T": The page title
-                'relevancy': int,     # "RK": How relevant is this result to the query? From 0 to 10
-                'appliance_id': str,  # "ENT_SOURCE": The serial number of the GSA
-                'summary': str,       # "S": Summary text for this result
-                'language': str,      # "LANG": The language of the page
-                'details': {}         # "FS": Name:value pairs of any extra info
+                'index': int,            # "R[N]": The number of this result in the index of all results
+                'url': str,              # "U": The URL of the resulting page
+                'encoded_url': str,      # "UE": The above URL, encoded
+                'title': str,            # "T": The page title
+                'relevancy': int,        # "RK": How relevant is this result to the query? From 0 to 10
+                'appliance_id': str,     # "ENT_SOURCE": The serial number of the GSA
+                'summary': str,          # "S": Summary text for this result
+                'language': str,         # "LANG": The language of the page
+                'details': {}            # "FS": Name:value pairs of any extra info
                 'link_supported': bool,  # "L": “link:” special query term is supported,
-                'cache': {  # "C": List, or "None" if cache information is missing
-                    'size': str,      # "C[SZ]": Human readable size of cached page
-                    'cache_id': str,  # "C[CID]": ID of document in GSA's cache
-                    'encoding': str   # "C[ENC]": The text encoding of the cached page
+                'cache': {               # "C": Dictionary, or "None" if cache is not available
+                    'size': str,         # "C[SZ]": Human readable size of cached page
+                    'cache_id': str,     # "C[CID]": ID of document in GSA's cache
+                    'encoding': str      # "C[ENC]": The text encoding of the cached page
                 }
             },
             ...
@@ -76,10 +75,10 @@ into a more readable format:
     }
 
 Filtering by domain or language
-~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can filter your search results by specifying specific domains or a
-[specific language](https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1077439).
+`specific language <https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1077439>`_.
 
 .. code:: python
 
@@ -91,13 +90,13 @@ You can filter your search results by specifying specific domains or a
     )
 
 Getting accurate totals
-~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 At the time of writing, the Google Search Appliance will return an "estimate" of
 the total number of results with each query, but this estimate is usually wildly
 inaccurate, sometimes out by more than a factor of 10!
 
-With the `total_results` method, the client will attempt to request results
+With the :code:`total_results` method, the client will attempt to request results
 990 - 1000. This will usually result in the GSA returning the last page of
 results, which allows us to find the actual total number of results.
 
@@ -106,15 +105,15 @@ results, which allows us to find the actual total number of results.
     total = search_client.total_results("hello world", domains=[], language='')
 
 Django view
-----
+-----------
 
 To simplify usage of the GSA client with Django, a Django view is included
 with this module.
 
 Usage
-~~~
+~~~~~
 
-At the minimum, need to provide the `SEARCH_SERVER_URL` setting to tell the view
+At the minimum, need to provide the :code:`SEARCH_SERVER_URL` setting to tell the view
 where to find the GSA:
 
 .. code:: python
@@ -130,11 +129,11 @@ where to find the GSA:
 
 This view will then be available to be queried:
 
-- `example.com/search?q=my+search+term`
-- `example.com/search?q=my+search+term&domain=example.com&domain=something.example.com`  (overrides `SEARCH_DOMAINS`)
-- `example.com/search?q=my+search+term&language=-lang_zh-CN`  (exclude results in Chinese, overrides `SEARCH_LANGUAGE`)
+- :code:`example.com/search?q=my+search+term`
+- :code:`example.com/search?q=my+search+term&domain=example.com&domain=something.example.com`  (overrides :code:`SEARCH_DOMAINS`)
+- :code:`example.com/search?q=my+search+term&language=-lang_zh-CN`  (exclude results in Chinese, overrides :code:`SEARCH_LANGUAGE`)
 
-After retrieving search results, the view will pass the context object to the specified `template_name` (in this case `search.html`).
+After retrieving search results, the view will pass the context object to the specified :code:`template_name` (in this case :code:`search.html`).
 
 The context object will be structured as follows:
 

--- a/README.rst
+++ b/README.rst
@@ -1,28 +1,159 @@
 Python GSA
 ==========
 
-A client library for the Google Search Appliance, to make retrieving search results in Python easier.
+A client library for the [Google Search Appliance](https://enterprise.google.com/search/products/gsa.html), to make retrieving search results in Python easier.
 
-Usage
+Installation
 ----
 
-.. code:: python 
+This module is in PyPi as `ubuntudesign.gsa`. You should be able to install it simply with:
+
+.. code:: bash
+
+    pip install ubuntudesign.gsa
+
+GSAClient
+----
+
+This is a basic client for querying a Google Search Appliance.
+
+Making queries
+~~~
+
+You can query the GSA using the `search` method.
+
+.. code:: python
 
     search_client = GSAClient(base_url="http://gsa.example.com/search")
-    results = search_client.search("hello world")
-    total = search_client.total_results("hello world")
+
+    first_ten_results = search_client.search("hello world")
+
+    first_thirty_results = search_client.search("hello world", num=30)
+
+    results_twenty_to_forty = search_client.search(
+      "hello world", start=20, num=20
+    )
+
+This will set the [`q`](https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1089652),
+[`start`](https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1076971) (default: 0) and
+[`num`](https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1076882) (default: 10) and
+[`lr`](https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1076879) (default: '') parameters.
+
+No other [search parameters](https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1086546),
+will be provided, so they will all fall back to their defaults.
+
+The returned results object will attempt to map each of the GSA's
+[standard result XML tags](https://www.google.com/support/enterprise/static/gsa/docs/admin/70/gsa_doc_set/xml_reference/results_format.html#1078461)
+into a more readable format:
+
+.. code:: python
+
+    {
+        'estimated_total_results': int,  # "M": GSA's estimate, see below
+        'document_filtering': bool,      # "FI": Is filtering enabled?
+        'next_url': str,                 # "NU": GSA URL for querying the next set of results, if available
+        'previous_url': str,             # "PU": Ditto for previous set of results
+        'items': [
+            {
+                'index': int,         # "R[N]": The number of this result in the index of all results
+                'url': str,           # "U": The URL of the resulting page
+                'encoded_url': str,   # "UE": The above URL, encoded
+                'title': str,         # "T": The page title
+                'relevancy': int,     # "RK": How relevant is this result to the query? From 0 to 10
+                'appliance_id': str,  # "ENT_SOURCE": The serial number of the GSA
+                'summary': str,       # "S": Summary text for this result
+                'language': str,      # "LANG": The language of the page
+                'details': {}         # "FS": Name:value pairs of any extra info
+                'link_supported': bool,  # "L": “link:” special query term is supported,
+                'cache': {  # "C": List, or "None" if cache information is missing
+                    'size': str,      # "C[SZ]": Human readable size of cached page
+                    'cache_id': str,  # "C[CID]": ID of document in GSA's cache
+                    'encoding': str   # "C[ENC]": The text encoding of the cached page
+                }
+            },
+            ...
+        ]
+    }
+
+Filtering by domain or language
+~~~
+
+You can filter your search results by specifying specific domains or a
+[specific language](https://www.google.com/support/enterprise/static/gsa/docs/admin/72/gsa_doc_set/xml_reference/request_format.html#1077439).
+
+.. code:: python
+
+    english_results = search_client.search("hello world", language="lang_en")
+    non_english_results = search_client.search("hello world", language="-lang_en")
+    domain_specific_results = search_client.search(
+        "hello world",
+        domains=["site1.example.com", "site2.example.com"]
+    )
+
+Getting accurate totals
+~~~
+
+At the time of writing, the Google Search Appliance will return an "estimate" of
+the total number of results with each query, but this estimate is usually wildly
+inaccurate, sometimes out by more than a factor of 10!
+
+With the `total_results` method, the client will attempt to request results
+990 - 1000. This will usually result in the GSA returning the last page of
+results, which allows us to find the actual total number of results.
+
+.. code:: python
+
+    total = search_client.total_results("hello world", domains=[], language='')
 
 Django view
 ----
 
-There is also a view for using this with Django:
+To simplify usage of the GSA client with Django, a Django view is included
+with this module.
+
+Usage
+~~~
+
+At the minimum, need to provide the `SEARCH_SERVER_URL` setting to tell the view
+where to find the GSA:
 
 .. code:: python
 
     # settings.py
-    SEARCH_SERVER_URL = 'http://gsa.example.com/search'
+    SEARCH_SERVER_URL = 'http://gsa.example.com/search'  # Required: GSA location
+    SEARCH_DOMAINS = ['site1.example.com']               # Optional: By default, limit results to this set of domains
+    SEARCH_LANGUAGE = 'lang_zh-CN'                       # Optional: By default, limit results to this language
 
     # urls.py
     from ubuntudesign.gsa.views import SearchView
     urlpatterns += [url(r'^search/?$', SearchView.as_view(template_name="search.html"))]
 
+This view will then be available to be queried:
+
+- `example.com/search?q=my+search+term`
+- `example.com/search?q=my+search+term&domain=example.com&domain=something.example.com`  (overrides `SEARCH_DOMAINS`)
+- `example.com/search?q=my+search+term&language=-lang_zh-CN`  (exclude results in Chinese, overrides `SEARCH_LANGUAGE`)
+
+After retrieving search results, the view will pass the context object to the specified `template_name` (in this case `search.html`).
+
+The context object will be structured as follows:
+
+.. code:: python
+
+    {
+        'query': str,       # The value of the `q` parameters passed to the view
+        'limit': int,       # The value of the `limit` parameter, or the default of 10
+        'offset': int,      # The value of the `offset` parameter, or the default of 0
+        'error': None|str,  # None, or a description of the error if one occurred
+        'results': {
+            'items': [],    # The list of items as returned from the GSAClient (see above)
+            'total': int,   # The exact total number of results available
+            'start': int,   # The index of the first result in the set
+            'end': int,     # The index of the last result in the set
+            'next_offset': int|None,      # The offset for the next page of results, if available
+            'previous_offset': int|None,  # The offset for the previous page of results, if available
+            'last_page_offset': int,      # The offset for the last page of results
+            'last_page': int,             # The final page number (calculated from "limit" and "total")
+            'current_page': int,          # The current page number (calculated from "limit" and "end")
+            'penultimate_page': int       # The second-to-last page
+    }

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,8 @@ You can filter your search results by specifying specific domains or a
         domains=["site1.example.com", "site2.example.com"]
     )
 
+*NB:* If no search results are found with the ``language`` filter applied, the GSA will fall back to returning any results it finds without filtering.
+
 Getting accurate totals
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='ubuntudesign.gsa',
-    version='0.1.1',
+    version='1.0.0',
     author='Canonical webteam',
     author_email='robin+pypi@canonical.com',
     url='https://github.com/ubuntudesign/python-gsa',

--- a/ubuntudesign/gsa/__init__.py
+++ b/ubuntudesign/gsa/__init__.py
@@ -93,32 +93,28 @@ class GSAClient:
                 'url': xml_text(item_element, 'U'),
                 'encoded_url': xml_text(item_element, 'UE'),
                 'title': xml_text(item_element, 'T'),
-                'relevancy': xml_text(item_element, 'RK'),
+                'relevancy': int(xml_text(item_element, 'RK')),
                 'appliance_id': xml_text(item_element, 'ENT_SOURCE'),
                 'summary': xml_text(item_element, 'S'),
                 'language': xml_text(item_element, 'LANG'),
-                'details': [],
-                'features': {}
+                'details': {},
+                'link_supported': bool(item_element.xpath('HAS/L')),
+                'cache': None
             }
 
             detail_elements = item_element.xpath('FS')
 
             for detail in detail_elements:
-                item['details'].append({
-                    detail.attrib['NAME']: detail.attrib['VALUE']
-                })
+                item['details'][detail.attrib['NAME']] = detail.attrib['VALUE']
 
-            features_elements = item_element.xpath('HAS/*')
+            cache_elements = item_element.xpath('HAS/C')
 
-            for feature in features_elements:
-                if feature.tag == 'L':
-                    item['features']['link_supported'] = True
-                if feature.tag == 'C':
-                    item['features']['cache'] = {
-                        'size': feature.attrib.get('SZ'),
-                        'cache_id': feature.attrib.get('CID'),
-                        'encoding': feature.attrib.get('ENC')
-                    }
+            if cache_elements:
+                item['cache'] = {
+                    'size': cache_elements[0].attrib.get('SZ'),
+                    'cache_id': cache_elements[0].attrib.get('CID'),
+                    'encoding': cache_elements[0].attrib.get('ENC')
+                }
 
             results['items'].append(item)
 

--- a/ubuntudesign/gsa/__init__.py
+++ b/ubuntudesign/gsa/__init__.py
@@ -29,7 +29,7 @@ class GSAClient:
     def __init__(self, base_url):
         self.base_url = base_url
 
-    def total_results(self, query, domains=[]):
+    def total_results(self, query, domains=[], language=""):
         """
         Inexplicably, the GSA returns a completely incorrect total
         This is a hack to get the correct total.
@@ -41,7 +41,10 @@ class GSAClient:
         Therefore this is the way to get the real total
         """
 
-        results = self.search(query, start=990, num=10, domains=domains)
+        results = self.search(
+            query,
+            start=990, num=10, domains=domains, language=language
+        )
 
         total = 0
 
@@ -50,7 +53,7 @@ class GSAClient:
 
         return int(total)
 
-    def search(self, query, start=0, num=10, domains=[]):
+    def search(self, query, start=0, num=10, domains=[], language=""):
         """
         Query the GSA to get response in XML format
         which it will then parse into a dictionary.
@@ -64,7 +67,8 @@ class GSAClient:
         query_parameters = urlencode({
             'q': query,
             'num': str(num),
-            'start': str(start)
+            'start': str(start),
+            'lr': language
         })
         search_url = self.base_url + '?' + query_parameters
 

--- a/ubuntudesign/gsa/views.py
+++ b/ubuntudesign/gsa/views.py
@@ -1,4 +1,5 @@
 # Core modules
+import math
 try:
     from urllib.parse import urlparse
     from urllib.error import URLError
@@ -6,7 +7,7 @@ except:
     from urlparse import urlparse
     from urllib2 import URLError
 import socket
-from requests import ConnectionError
+import requests
 
 # Third party modules
 from django.conf import settings
@@ -79,14 +80,6 @@ class SearchView(TemplateView):
             items = server_results['items']
 
             total = search_client.total_results(query, domains=domains)
-            start = None
-            end = None
-
-            remainder = total % limit
-            if remainder == 0:
-                last_page_offset = total - offset
-            else:
-                last_page_offset = total - remainder
 
             results = {
                 'items': items,
@@ -96,25 +89,36 @@ class SearchView(TemplateView):
             if total > 0:
                 start = items[0]['index']
                 end = items[-1]['index']
+                last_page = int(math.ceil(float(total) / limit))
+                penultimate_page = last_page - 1
+                current_page = int(math.ceil(float(end) / limit))
+                last_page_offset = limit * penultimate_page
+                next_offset = offset + limit
+                previous_offset = offset - limit
+                if next_offset >= total:
+                    next_offset = None
+                if previous_offset < 0:
+                    previous_offset = None
 
                 results.update({
                     'start': start,
                     'end': end,
-                    'next_offset': offset + limit,
-                    'previous_offset': offset - limit,
+                    'next_offset': next_offset,
+                    'previous_offset': previous_offset,
                     'last_page_offset': last_page_offset,
-                    'last_page': start > last_page_offset,
-                    'penultimate_page': (
-                        start < last_page_offset and
-                        start >= last_page_offset - limit
-                    ),
-                    'first_page': start == 1,
-                    'second_page': start > 1 and start <= (limit + 1)
+                    'last_page': last_page,
+                    'penultimate_page': penultimate_page,
+                    'current_page': current_page
                 })
+
+                if offset + limit < total:
+                    results['next_offset'] = offset + limit
+                if offset - limit >= 0:
+                    results['previous_offset'] = offset - limit
 
         except URLError:
             error = 'request error'
-        except ConnectionError:
+        except requests.ConnectionError:
             error = 'connection error'
         except socket.error:
             error = 'host error'

--- a/ubuntudesign/gsa/views.py
+++ b/ubuntudesign/gsa/views.py
@@ -56,11 +56,18 @@ class SearchView(TemplateView):
         """
 
         search_server_url = settings.SEARCH_SERVER_URL
-        domains = getattr(settings, "SEARCH_DOMAINS", [])
         search_host = urlparse(search_server_url).netloc
         search_client = GSAClient(search_server_url)
 
         query = self.request.GET.get('q', '').encode('utf-8')
+        domains = (
+            self.request.GET.getlist('domain') or
+            getattr(settings, "SEARCH_DOMAINS", [])
+        )
+        language = (
+            self.request.GET.get('language') or
+            getattr(settings, "SEARCH_LANGUAGE", '')
+        )
         limit = int(self.request.GET.get('limit', '10'))
         offset = int(self.request.GET.get('offset', '0'))
         results = {}
@@ -75,11 +82,16 @@ class SearchView(TemplateView):
                 socket.gethostbyname(search_host)
 
             server_results = search_client.search(
-                query, start=offset, num=limit, domains=domains
+                query,
+                start=offset, num=limit, domains=domains, language=language
             )
             items = server_results['items']
 
-            total = search_client.total_results(query, domains=domains)
+            total = search_client.total_results(
+                query,
+                domains=domains,
+                language=language
+            )
 
             results = {
                 'items': items,


### PR DESCRIPTION
- Add language filtering through SEARCH_LANGUAGE setting
- Add domain or language filtering with query params
- Massively improve the README
- Data structure improvements

QA
--

Build a local python environment for, say, developer.ubuntu.com:

``` bash
git clone git@github.com/ubuntudesign/developer.ubuntu.com
cd developer.ubuntu.com
virtualenv env
source env/bin/activate
pip install -r requirements.txt
```

Remove `ubuntudesign.gsa` and replace it with this one:

``` bash
pip uninstall ubuntudesign.gsa
pip install [path/to/this/branch]
```

Run the site

```
./manage.py runserver
```

Check a bunch of searches at <127.0.0.1:8000/search>. Search will look broken because the context object has been restructured. This is expected.

Play around with `domain=` and `language=` query string (follow the README), and with the `SEARCH_DOMAINS` and `SEARCH_LANGUAGE` Django settings.