### PR TITLE
Fix domain filtering

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
-v0.1.0, 2017-01-26 -- Initial release
-v0.1.1, 2017-01-26 -- Support filtering by domain in GSAClient
-v1.0.0, 2017-01-27 -- Support filtering by language; restructure data objects
+v0.1.0, 2017-01-25 -- Initial release
+v0.1.1, 2017-01-25 -- Support filtering by domain in GSAClient
+v1.0.0, 2017-01-26 -- Support filtering by language; restructure data objects
+v1.0.1, 2017-01-27 -- Fix domain filtering
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,4 +2,5 @@ v0.1.0, 2017-01-25 -- Initial release
 v0.1.1, 2017-01-25 -- Support filtering by domain in GSAClient
 v1.0.0, 2017-01-26 -- Support filtering by language; restructure data objects
 v1.0.1, 2017-01-27 -- Fix domain filtering
+v1.0.2, 2017-01-27 -- Be more permissive with dependency versioning
 

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ You can filter your search results by specifying specific domains or a
         domains=["site1.example.com", "site2.example.com"]
     )
 
-*NB:* If no search results are found with and of the filters applied, the GSA will fall back to returning any results it finds without filtering. So for example, if you're asking for Chinese documents, but the GSA only finds results in English, it will still return those results. Similarly, if it can't find any results in the requested domains, it will simply return results from all domains.
+*NB:* If no search results are found with the specified ``language``, the GSA will fall back to returning any results it finds in all languages.
 
 Getting accurate totals
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='ubuntudesign.gsa',
-    version='1.0.0',
+    version='1.0.1',
     author='Canonical webteam',
     author_email='robin+pypi@canonical.com',
     url='https://github.com/ubuntudesign/python-gsa',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='ubuntudesign.gsa',
-    version='1.0.1',
+    version='1.0.2',
     author='Canonical webteam',
     author_email='robin+pypi@canonical.com',
     url='https://github.com/ubuntudesign/python-gsa',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
     ),
     long_description=open('README.rst').read(),
     install_requires=[
-        "requests==2.10.0",
-        "lxml==3.7.2"
+        "requests>=2.10.0",
+        "lxml>=3.3.0"
     ],
 )
+

--- a/ubuntudesign/gsa/__init__.py
+++ b/ubuntudesign/gsa/__init__.py
@@ -62,7 +62,7 @@ class GSAClient:
         # Filter by domains, if specified
         if domains:
             domain_filters = ['site:' + domain for domain in domains]
-            query += ' (' + " | ".join(domain_filters) + ')'
+            query += ' ( ' + " | ".join(domain_filters) + ' )'
 
         # Build the GSA URL
         query_parameters = urlencode({

--- a/ubuntudesign/gsa/__init__.py
+++ b/ubuntudesign/gsa/__init__.py
@@ -61,7 +61,8 @@ class GSAClient:
 
         # Filter by domains, if specified
         if domains:
-            query += ' (' + " | ".join(domains) + ')'
+            domain_filters = ['site:' + domain for domain in domains]
+            query += ' (' + " | ".join(domain_filters) + ')'
 
         # Build the GSA URL
         query_parameters = urlencode({


### PR DESCRIPTION
Domain filtering was broken, in that it searched with (domain | domain) rather than (site:domain, site:domain).

This meant that it didn't accurately choose the domains it should.

Now it's fixed.

QA
---

Grab a codebase that has search implemented, and install requirements:

``` bash
git clone https://github.com/ubuntudesign/developer.ubuntu.com && cd developer.ubuntu.com
./run npm run-script watch  # Run, then cancel out, to rebuild sass
virtualenv env
env/bin/pip install -r requirements.txt
```

Now uninstall `ubuntudesign.gsa`, and install this branch instead:

``` bash
env/bin/pip uninstall ubuntudesign.gsa
env/bin/pip install https://github.com/nottrobin/ubuntudesign.gsa/archive/fix-domain-filtering.zip
```

Run the site:

``` bash
env/bin/python runserver 0.0.0.0:8015
```

Check <http://127.0.0.1:8015/search> works properly. Specifically, check that the "domain" filter will only return results from that domains - e.g. at <http://127.0.0.1:8015/search?q=core&domain=tutorials.ubuntu.com> <- should be empty.
