### PR TITLE
Pass domains to template

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,4 +5,5 @@ v1.0.1, 2017-01-27 -- Fix domain filtering
 v1.0.2, 2017-01-27 -- Be more permissive with dependency versioning
 v1.0.3, 2017-01-31 -- Timouts for communicating with search server
 v1.0.4, 2017-01-31 -- Catch timeout errors properly in the view
+v1.0.5, 2017-02-21 -- Pass the "domains" info through to the template
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='ubuntudesign.gsa',
-    version='1.0.4',
+    version='1.0.5',
     author='Canonical webteam',
     author_email='robin+pypi@canonical.com',
     url='https://github.com/ubuntudesign/python-gsa',

--- a/ubuntudesign/gsa/views.py
+++ b/ubuntudesign/gsa/views.py
@@ -134,6 +134,7 @@ class SearchView(TemplateView):
         template_context['query'] = query
         template_context['limit'] = limit
         template_context['offset'] = offset
+        template_context['domains'] = domains
         template_context['error'] = error
 
         return template_context


### PR DESCRIPTION
In the view, add domains to the template context.

We will need to be able to see the domains in the view going forward.

Also upgrade to 1.0.5.

QA
--

``` bash
git clone git@github.com:ubuntudesign/www.ubuntu.com.git && cd www.ubuntu.com
virtualenv env
env/bin/pip install git+https://github.com/nottrobin/ubuntudesign.gsa.git@pass-domains-through
env/bin/python ./manage.py 0.0.0.0:8001
```

Edit the [templates/search.html](https://github.com/ubuntudesign/www.ubuntu.com/blob/master/templates/search.html) to make use of the new `domains` list item.

Load the search page <http://127.0.0.1:8001/search?q=something&domains=docs.ubuntu.com>, check domains is passed through (you'll need to be connected to the VPN to get search results).