### PR TITLE
 Use estimated total results in view 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,4 +7,4 @@ v1.0.3, 2017-01-31 -- Timouts for communicating with search server
 v1.0.4, 2017-01-31 -- Catch timeout errors properly in the view
 v1.0.5, 2017-02-21 -- Pass the "domains" info through to the template
 v1.1.0, 2017-05-22 -- Python3 compatibility
-
+v1.2.0, 2018-01-10 -- Use GSA estimated total for amount of results.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='ubuntudesign.gsa',
-    version='1.1.0',
+    version='1.2.0',
     author='Canonical webteam',
     author_email='robin+pypi@canonical.com',
     url='https://github.com/ubuntudesign/python-gsa',

--- a/ubuntudesign/gsa/__init__.py
+++ b/ubuntudesign/gsa/__init__.py
@@ -29,30 +29,6 @@ class GSAClient:
     def __init__(self, base_url):
         self.base_url = base_url
 
-    def total_results(self, query, domains=[], language=""):
-        """
-        Inexplicably, the GSA returns a completely incorrect total
-        This is a hack to get the correct total.
-
-        If you request with start>1000, the GSA returns nothing.
-        But if you request with start = 990, it returns the last page
-        even if there are only 10 results.
-
-        Therefore this is the way to get the real total
-        """
-
-        results = self.search(
-            query,
-            start=990, num=10, domains=domains, language=language
-        )
-
-        total = 0
-
-        if results['items']:
-            total = results['items'][-1]['index']
-
-        return int(total)
-
     def search(
         self, query,
         start=0, num=10, domains=[], language="", timeout=30
@@ -62,12 +38,11 @@ class GSAClient:
         which it will then parse into a dictionary.
         """
 
+        query_string = query.decode()
+
         # Filter by domains, if specified
         if domains:
             domain_filters = ['site:' + domain for domain in domains]
-
-            query_string = query.decode()
-
             query_string += ' ( ' + " | ".join(domain_filters) + ' )'
 
         # Build the GSA URL

--- a/ubuntudesign/gsa/views.py
+++ b/ubuntudesign/gsa/views.py
@@ -77,11 +77,7 @@ class SearchView(TemplateView):
                 )
                 items = server_results['items']
 
-                total = search_client.total_results(
-                    query,
-                    domains=domains,
-                    language=language
-                )
+                total = server_results['estimated_total_results']
 
                 results = {
                     'items': items,


### PR DESCRIPTION
The code we previously used to return the total amount of results has
stopped working in a recent update to GSA. This changes to use the
default estimated value that GSA returns.

## QA

- Checkout https://github.com/canonical-websites/www.ubuntu.com
- Checkout this repo
- Set up a Python virtual environment ([Some docs](http://docs.python-guide.org/en/latest/dev/virtualenvs/))
- Inside www.ubuntu.com and using the virtual environment
 - `pip install -r requirements.txt`
 - `python manage.py runserver`
 - Visit http://127.0.0.1:8000/search?q=juju and it will say 0 results
 - Now install your local gsa repo with `pip install --editable [PATH_TO_THIS_REPO]`
 - Restart the server and visit the URL again. It should show more than 0 results.